### PR TITLE
Investigating SPM Support (via Hosted Binaries)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "SquareInAppPaymentsSDK",
+    products: [
+        .library(name: "SquareBuyerVerificationSDK", targets: ["SquareBuyerVerificationSDK"]),
+        .library(name: "SquareInAppPaymentsSDK", targets: ["SquareInAppPaymentsSDK"]),
+    ],
+    dependencies: [],
+    targets: [
+        .binaryTarget(
+            name: "SquareBuyerVerificationSDK",
+            // TODO: URL and checksum must be updated when hosted by Square.
+            url: "https://github.com/bdrelling/in-app-payments-ios/releases/download/1.6.0/SquareBuyerVerificationSDK.zip",
+            checksum: "1bc10b0ff90a8f46febd1c4566cf39935f0a02a2fccd8032211186535650fe73"
+        ),
+        .binaryTarget(
+            name: "SquareInAppPaymentsSDK",
+            // TODO: URL and checksum must be updated when hosted by Square.
+            url: "https://github.com/bdrelling/in-app-payments-ios/releases/download/1.6.0/SquareInAppPaymentsSDK.zip",
+            checksum: "8a82d53c41f048d5df5be0eeb97969a5ffe17b5fd73f21f7b4667ad4f210a783"
+        ),
+    ]
+)

--- a/compute_checksum.sh
+++ b/compute_checksum.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+# The purpose of this script is to demonstrate generating a checksum for the Square SDKs .zip file.
+# Unfortunately, it seems that binary target support requires there is one XCFramework at the downloaded source.
+
+# This script is NOT intended to be used by Square for distribution or otherwise,
+# as the underlying process (of combining frameworks into a single zip and adding to a release)
+# is not the proper way to support hosted binaries in SPM.
+
+# This script should be deleted or heavily modified prior to merging into the Square in-app-payments-ios repository.
+
+framework_directory="SquareInAppPaymentsSDKs"
+zip_filename="$framework_directory.zip"
+url="https://github.com/square/in-app-payments-ios/releases/download/1.5.4/${zip_filename}"
+
+buyer_verification_name="SquareBuyerVerificationSDK"
+buyer_verification_framework="${buyer_verification_name}.xcframework"
+buyer_verification_zip="${buyer_verification_name}.zip"
+
+in_app_payments_name="SquareInAppPaymentsSDK"
+in_app_payments_framework="${in_app_payments_name}.xcframework"
+in_app_payments_zip="${in_app_payments_name}.zip"
+
+# Download the .zip containing the XCFrameworks.
+wget $url --quiet
+
+# Unzip the .zip.
+# -qq = quiet
+unzip -qq $zip_filename 
+
+# Navigte into the framework directory.
+# If we don't, the zip file is generated with an additional directory at the top-level.
+cd $framework_directory
+
+# Make directories for each XCFramework.
+mkdir $buyer_verification_name
+mkdir $in_app_payments_name
+
+# Move the frameworks into the appropriate directories.
+# NOTE: This will ensure that the XCFramework is contained within the zip,
+#       rather than having its contents zipped directly, which appears invalid via SPM.
+mv $buyer_verification_framework "${buyer_verification_name}/${buyer_verification_framework}"
+mv $in_app_payments_framework "${in_app_payments_name}/${in_app_payments_framework}"
+
+# Zip each xcframework individually.
+# -q = quiet
+# -r = recursive
+zip $buyer_verification_zip $buyer_verification_name -q -r
+zip $in_app_payments_zip $in_app_payments_name -q -r
+
+# Compute checksums for each SDK
+buyer_verification_sdk_checksum=`swift package compute-checksum $buyer_verification_zip`
+echo "Buyer Verification SDK Checksum: $buyer_verification_sdk_checksum"
+
+in_app_payments_sdk_checksum=`swift package compute-checksum $in_app_payments_zip`
+echo "In App Payments SDK Checksum: $in_app_payments_sdk_checksum"
+
+# Delete the .zip and framework directory.
+rm ../$zip_filename


### PR DESCRIPTION
**This PR is meant for demonstration only, and is not in a working state.**

This PR offers an investigation into adding SPM support via **hosted** binaries. To get these binaries, I simply grabbed the latest from the `1.5.4` release.

While source-controlled binary support worked flawlessly (which can be found in #31), hosted binary support runs into errors download the .zip file, which seem to be generic in nature and mask an underlying error.

In trying to identify the problem, I attempted the following:
- Keeping the .zip in a single directory and referencing the `1.5.4` release zip URL directly. This doesn't work, and upon further research, it seems SPM expects _one_ XCFramework for the `binaryTarget` url entry in the Package.swift manifest.
- Splitting the .zip out into two .zip files, each with a unique checksum and library entry, with the `.xcframework` directory as the root.
- Splitting the .zip out into two .zip files, each with a unique checksum and library entry, with the `.xcframework` directory as a _child_ of the .zip root.

None of the above worked, so I wanted to document it a bit and put it up for discussion. Unfortunately, I have no visibility into the distribution process for Square's frameworks, so I can't offer much more troubleshooting. 

**Details**
- Added a `Package.swift` file with binary target support.
- Swift tools version is set to `5.3`, which is when support for binary targets was introduced.
- `compute_checksum.sh` is provided primarily to showcase the `swift package compute-checksum` command, but it quickly became a script for attempting to easily pull down the hosted `1.5.4` framework and modify it for SPM compatibility.
- Given that #31 shows that the binaries are valid, we can safely assume this is not an issue with how the XCFramework binaries are generated.

**Open Items**
- The rest of the Square distribution system is a black box right now, so however these binaries are being distributed will need to change to support this strategy moving forward if this PR if merged.
- Ideally, Square would split these unrelated packages into two separate repositories, to further reduce the size of the binaries being pulled in to resolve a package, and also because these frameworks don't appear to be coupled in the slightest. This would help with both source-controlled and hosted solution.
- It would help if Square could upload both frameworks as independent zips to an S3 bucket or something similar, that way the release and the Package.swift manifest weren't so tightly coupled to one another, which would make investigation easier without needing to host the files elsewhere myself.