### PR TITLE
Removed Apple Silicon disabler from Cocoapods.

### DIFF
--- a/SquareBuyerVerificationSDK.podspec
+++ b/SquareBuyerVerificationSDK.podspec
@@ -16,7 +16,4 @@ Pod::Spec.new do |s|
 
   s.source = SquareInAppPaymentsSDK::SOURCE
   s.vendored_frameworks = "#{SquareInAppPaymentsSDK::CONTAINER_FOLDER_NAME}/#{framework_filename}"
-
-  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end

--- a/SquareInAppPaymentsSDK.podspec
+++ b/SquareInAppPaymentsSDK.podspec
@@ -16,7 +16,4 @@ Pod::Spec.new do |s|
 
   s.source = SquareInAppPaymentsSDK::SOURCE
   s.vendored_frameworks = "#{SquareInAppPaymentsSDK::CONTAINER_FOLDER_NAME}/#{framework_filename}"
-
-  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end


### PR DESCRIPTION
Since the framework now supports ARM64 Simulators these lines are not needed and will force any project that uses this pod to run in Rosetta while using the simulator on Apple Silicon.